### PR TITLE
changed to actions/checkout@v4

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v1
       - name: Upload artifact


### PR DESCRIPTION
Assuming this will help fix the deploy to gh pages action failing.,